### PR TITLE
Add documentation for SHT35 sensor example

### DIFF
--- a/python/sensors/bme280/README.md
+++ b/python/sensors/bme280/README.md
@@ -1,10 +1,12 @@
-# BME280 sensor example
+# Environmental sensor examples
 
-This Python script interfaces with a BME280 environmental sensor via the I²C protocol to read and print temperature, humidity, and pressure data continuously.
+This directory groups together I²C-based environmental sensor examples for the BeagleBone Green. Each subdirectory contains a dedicated script and README describing the expected wiring and usage instructions.
 
-The BME280 sensor supports atmospheric data acquisition and is widely used in weather stations, IoT applications, and embedded systems.
+## BME280 (temperature, humidity, pressure)
 
-## Requirements
+`bme280.py` demonstrates how to read data from a Bosch BME280 sensor and print temperature, humidity, and pressure values in a loop.
+
+### Requirements
 
 ```bash
 sudo apt update
@@ -12,3 +14,7 @@ sudo apt install python3-smbus python3-pip python3-bme280 i2c-tools
 ```
 
 Ensure your BeagleBone Green runs kernel version `6.15.9-bone25` or newer and that the BME280 sensor is connected to the J4 header.
+
+## SHT35 (temperature, humidity)
+
+The `sht35/` folder contains an example that communicates with a Sensirion SHT35 sensor using the `smbus2` library. Refer to [`sht35/README.md`](sht35/README.md) for hardware notes, software dependencies, and execution steps.

--- a/python/sensors/bme280/sht35/README.md
+++ b/python/sensors/bme280/sht35/README.md
@@ -1,0 +1,38 @@
+# SHT35 temperature and humidity sensor example
+
+This directory contains a Python script for reading a Sensirion SHT35 (or other SHT3x-series) temperature and humidity sensor that is connected to the BeagleBone Green via I²C. The script continuously prints temperature (°C) and relative humidity (%RH) readings to the console and performs CRC checks to validate the data returned by the sensor.
+
+## Hardware setup
+
+- Connect the Grove SHT35 to the BeagleBone Green's I²C bus on header J4 using the Grove cape or jumper wires.
+- The example assumes the device is available on `/dev/i2c-2` with address `0x45`. Adjust `I2C_BUS` or `SHT3X_ADDRESS` in `sht35.py` if your wiring uses a different bus or the sensor responds on `0x44`.
+
+## Software requirements
+
+Install the required libraries and enable the I²C interface if you have not already:
+
+```bash
+sudo apt update
+sudo apt install python3-pip python3-smbus i2c-tools
+pip3 install --user smbus2
+```
+
+You can verify the sensor is present by running `i2cdetect -y 2` and confirming that the expected address appears in the map.
+
+## Running the example
+
+Execute the script directly to start an interactive readout loop. Press <kbd>Ctrl</kbd>+<kbd>C</kbd> to stop the program.
+
+```bash
+cd ~/BeagleBoneGreen/python/sensors/bme280/sht35
+python3 sht35.py
+```
+
+On each iteration you should see output similar to the following:
+
+```
+Temperature: 22.41 °C
+Humidity:    47.08 %RH
+```
+
+Transient I²C errors and CRC mismatches are reported but the loop continues so the sensor can recover on the next cycle.


### PR DESCRIPTION
## Summary
- add a README for the new SHT35 temperature and humidity script with setup and usage notes
- reorganize the bme280 sensor README so it introduces both the BME280 and SHT35 examples

## Testing
- not run (documentation-only change)


------