### PR TITLE
Fix sensor documentation paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains small experiments and demonstrations for the BeagleBone
 - `python/`
   - `games/` – Console games and exercises originally written for fun while experimenting with Python.
   - `gpio/` – Scripts that exercise the BeagleBone Green GPIO lines using `libgpiod`.
-  - `sensors/` – Drivers and helpers for hardware such as the BME280 environmental sensor.
+  - `sensors/` – Drivers and helpers for hardware such as the BME280 and SHT35 environmental sensors.
 - `javascript/`
   - `games/` – Browser games created alongside the Python experiments.
   - `usr_led_blink.js` – Example that toggles the on-board USR LED from Node.js.

--- a/python/sensors/README.md
+++ b/python/sensors/README.md
@@ -1,0 +1,13 @@
+# Sensor examples
+
+This directory groups together sensor demos that were written for the
+BeagleBone Green. Each subfolder focuses on a specific device and
+contains a stand-alone script plus detailed instructions.
+
+- `bme280/` – Reads temperature, humidity, and pressure data from a Bosch
+  BME280 environmental sensor using the `bme280` helper library.
+- `sht35/` – Communicates with a Sensirion SHT35 (SHT3x-series) sensor
+  over I²C and includes CRC validation of the returned measurements.
+
+Consult the README in each subdirectory for wiring notes, package
+requirements, and example commands.

--- a/python/sensors/bme280/README.md
+++ b/python/sensors/bme280/README.md
@@ -1,20 +1,27 @@
-# Environmental sensor examples
+# BME280 environmental sensor example
 
-This directory groups together I²C-based environmental sensor examples for the BeagleBone Green. Each subdirectory contains a dedicated script and README describing the expected wiring and usage instructions.
+This folder contains a Python script that reads temperature, humidity,
+and pressure data from a Bosch BME280 sensor connected to the
+BeagleBone Green via I²C.
 
-## BME280 (temperature, humidity, pressure)
-
-`bme280.py` demonstrates how to read data from a Bosch BME280 sensor and print temperature, humidity, and pressure values in a loop.
-
-### Requirements
+## Requirements
 
 ```bash
 sudo apt update
 sudo apt install python3-smbus python3-pip python3-bme280 i2c-tools
 ```
 
-Ensure your BeagleBone Green runs kernel version `6.15.9-bone25` or newer and that the BME280 sensor is connected to the J4 header.
+## Running the example
 
-## SHT35 (temperature, humidity)
+1. Connect the BME280 to the `/dev/i2c-2` bus on the BeagleBone Green
+   (typically header J4) and confirm the device appears with
+   `i2cdetect -y 2`.
+2. From this directory, run the script:
 
-The `sht35/` folder contains an example that communicates with a Sensirion SHT35 sensor using the `smbus2` library. Refer to [`sht35/README.md`](sht35/README.md) for hardware notes, software dependencies, and execution steps.
+   ```bash
+   cd ~/BeagleBoneGreen/python/sensors/bme280
+   python3 bme280.py
+   ```
+
+The script prints the measured values every few seconds until you press
+<kbd>Ctrl</kbd>+<kbd>C</kbd>.

--- a/python/sensors/sht35/README.md
+++ b/python/sensors/sht35/README.md
@@ -24,7 +24,7 @@ You can verify the sensor is present by running `i2cdetect -y 2` and confirming 
 Execute the script directly to start an interactive readout loop. Press <kbd>Ctrl</kbd>+<kbd>C</kbd> to stop the program.
 
 ```bash
-cd ~/BeagleBoneGreen/python/sensors/bme280/sht35
+cd ~/BeagleBoneGreen/python/sensors/sht35
 python3 sht35.py
 ```
 


### PR DESCRIPTION
## Summary
- add a dedicated README for the `python/sensors` directory that lists the available sensor demos
- rewrite the BME280 README so it only documents the BME280 example and provides accurate run instructions
- correct the `cd` path in the SHT35 README and mention both sensors in the repository overview

------